### PR TITLE
Fix: Correct import statement placement in RegisterPage.js

### DIFF
--- a/frontend/src/pages/RegisterPage.js
+++ b/frontend/src/pages/RegisterPage.js
@@ -1,23 +1,4 @@
 import React, { useState } from 'react';
-
-function RegisterPage({ onRegisterSuccess, API_BASE_URL }) {
-    const [email, setEmail] = useState('');
-    const [password, setPassword] = useState('');
-    const [confirmPassword, setConfirmPassword] = useState('');
-    const [error, setError] = useState('');
-    const [successMessage, setSuccessMessage] = useState('');
-    const [isLoading, setIsLoading] = useState(false);
-
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        setError('');
-        setSuccessMessage('');
-        setIsLoading(true);
-
-        if (password !== confirmPassword) {
-            setError('Passwords do not match.');
-            setIsLoading(false);
-            return;
 import { registerUser } from '../services/authService';
 
 function RegisterPage({ onRegisterSuccess, API_BASE_URL }) {


### PR DESCRIPTION
Removes a duplicate, incomplete RegisterPage component declaration that contained a misplaced import statement. Ensures that `import { registerUser } from '../services/authService';` is at the top level of the module.

This resolves the SyntaxError: "'import' and 'export' may only appear at the top level."